### PR TITLE
chore: correct website URL in library `package.json`

### DIFF
--- a/packages/react-native-legal/package.json
+++ b/packages/react-native-legal/package.json
@@ -24,7 +24,7 @@
   "bugs": {
     "url": "https://github.com/callstackincubator/react-native-legal/issues"
   },
-  "homepage": "https://github.com/callstackincubator/react-native-legal#readme",
+  "homepage": "https://callstackincubator.github.io/react-native-legal/",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },


### PR DESCRIPTION
# Why

After adding package to the React Native Directory spotted that library `package.json` file uses GitHub readme link for homepage, instead of the library website:
* https://reactnative.directory/?search=legal

# How

Update the `hompage` field in library `package.json` to point to https://callstackincubator.github.io/react-native-legal/ website.