### PR TITLE
fix(#19): library support for ios use_frameworks

### DIFF
--- a/.changeset/proud-crabs-teach.md
+++ b/.changeset/proud-crabs-teach.md
@@ -1,0 +1,5 @@
+---
+"react-native-legal": patch
+---
+
+fix(#19): library support for ios use_frameworks

--- a/packages/react-native-legal/ios/ReactNativeLegalModule.mm
+++ b/packages/react-native-legal/ios/ReactNativeLegalModule.mm
@@ -1,6 +1,10 @@
 #import "ReactNativeLegalModule.h"
 
+#if __has_include(<ReactNativeLegal/ReactNativeLegal-Swift.h>)
+#import <ReactNativeLegal/ReactNativeLegal-Swift.h>
+#else
 #import "ReactNativeLegal-Swift.h"
+#endif
 
 #if RCT_NEW_ARCH_ENABLED
 #import "ReactNativeLegal.h"


### PR DESCRIPTION
Fixes #19 

With `use_frameworks!` setting in Cocoapods, ios projects are using dynamic frameworks, which means we the imports are different - let's support it with simple __has_include condition and use correct import

(__has_include is supported from C++17 and RN projects done from helloworld template are using C++20 since at least version 0.73, so we're safe to use it)