### PR TITLE
refactor: improve package scanning to support workspace:* dependencies

### DIFF
--- a/.changeset/mighty-parks-exist.md
+++ b/.changeset/mighty-parks-exist.md
@@ -1,0 +1,6 @@
+---
+'react-native-legal': minor
+---
+
+License scanning now includes dependencies of `workspace:*` packages, not just the app's direct dependencies.  
+


### PR DESCRIPTION
License scanning now includes dependencies of workspace:* packages, not just the app's direct dependencies.

> [!IMPORTANT]  
> If a monorepo package is private, its name and license won't be included, but its dependencies will.