### PR TITLE
fix(plugin-utils): prevent YAML errors caused by inconsistent indentation

### DIFF
--- a/.changeset/lazy-pugs-reply.md
+++ b/.changeset/lazy-pugs-reply.md
@@ -1,0 +1,5 @@
+---
+'react-native-legal': patch
+---
+
+Fixes an issue where licenses with unusual indentation caused YAML errors, breaking the LicencePlist script during the build. This ensures proper processing and prevents build failures.

--- a/packages/react-native-legal/plugin-utils/src/common.ts
+++ b/packages/react-native-legal/plugin-utils/src/common.ts
@@ -8,6 +8,7 @@ type LicenseObj = {
   author?: string;
   content?: string;
   description?: string;
+  file?: string;
   type?: string;
   url?: string;
   version: string;
@@ -31,10 +32,11 @@ type AboutLibrariesLicenseJsonPayload = {
 };
 
 type LicensePlistPayload = {
-  body: string;
   name: string;
   source?: string;
   version: string;
+  body?: string;
+  file?: string;
 };
 
 function compareObjects(a: unknown, b: unknown): boolean {
@@ -110,6 +112,7 @@ function scanPackage(
       result[packageName] = {
         author: parseAuthorField(localPackageJson),
         content: licenseFiles?.[0] ? fs.readFileSync(licenseFiles[0], { encoding: 'utf-8' }) : undefined,
+        file: licenseFiles?.[0] ? licenseFiles[0] : undefined,
         description: localPackageJson.description,
         type: parseLicenseField(localPackageJson),
         url: parseRepositoryFieldToUrl(localPackageJson),
@@ -243,11 +246,15 @@ export function generateLicensePlistNPMOutput(licenses: Record<string, LicenseOb
       renames[normalizedName] = dependency;
     }
 
+    const relativeLicenseFile = licenseObj.file ? path.relative(iosProjectPath, licenseObj.file) : undefined;
+
     return {
       name: normalizedName,
       version: licenseObj.version,
       ...(licenseObj.url && { source: licenseObj.url }),
-      body: licenseObj.content ?? licenseObj.type ?? 'UNKNOWN',
+      ...(licenseObj.file
+        ? { file: relativeLicenseFile }
+        : { body: licenseObj.content ?? licenseObj.type ?? 'UNKNOWN' }),
     } as LicensePlistPayload;
   });
 


### PR DESCRIPTION
LicencePlist was failing during the build due to YAML misinterpreting certain license files with irregular indentation. When a line was indented more and then followed by a less-indented line, YAML treated it as a new key instead of part of the existing content.

Instead of always embedding the license content as a body, the script now uses file path when available. This prevents YAML from incorrectly splitting content into new keys and ensures the build process runs without errors.
Since this only affected licenses with inconsistent indentation, most users should not notice any changes.