### PR TITLE
feat(android): auto-switch dark theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
       "@commitlint/config-conventional"
     ]
   },
-  "packageMaager": "yarn@3.6.1"
+  "packageMaager": "yarn@3.6.1",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/react-native-legal/android/src/main/java/com/reactnativelegal/ReactNativeLegalActivity.kt
+++ b/packages/react-native-legal/android/src/main/java/com/reactnativelegal/ReactNativeLegalActivity.kt
@@ -1,11 +1,13 @@
 package com.reactnativelegal
 
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import com.mikepenz.aboutlibraries.LibsBuilder.Companion.BUNDLE_TITLE
@@ -22,6 +24,15 @@ class ReactNativeLegalActivity : AppCompatActivity() {
         setTheme(R.style.ReactNativeLegalTheme)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_licenses)
+
+        val isLightTheme =
+            resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK !=
+                Configuration.UI_MODE_NIGHT_YES
+
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+            isAppearanceLightStatusBars = isLightTheme
+            isAppearanceLightNavigationBars = isLightTheme
+        }
 
         val bundle = intent.extras
         fragment = LibsSupportFragment().apply { arguments = bundle }
@@ -41,6 +52,11 @@ class ReactNativeLegalActivity : AppCompatActivity() {
             .commit()
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        recreate()
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
             onBackPressedDispatcher.onBackPressed()
@@ -56,7 +72,7 @@ class ReactNativeLegalActivity : AppCompatActivity() {
     }
 
     private fun setupToolbar(bundle: Bundle?) {
-        val title = bundle?.let { it.getString(BUNDLE_TITLE, "") } ?: ""
+        val title = bundle?.getString(BUNDLE_TITLE, "") ?: ""
 
         val toolbar = findViewById<Toolbar>(R.id.toolbar)
         setSupportActionBar(toolbar)

--- a/packages/react-native-legal/android/src/main/res/values-night/colors.xml
+++ b/packages/react-native-legal/android/src/main/res/values-night/colors.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="surface">#121212</color>
+</resources>

--- a/packages/react-native-legal/android/src/main/res/values-v29/styles.xml
+++ b/packages/react-native-legal/android/src/main/res/values-v29/styles.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="ReactNativeLegalTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
-        <item name="android:statusBarColor">#F3EFEE</item>
-        <item name="android:windowBackground">#F3EFEE</item>
-        <item name="android:forceDarkAllowed">false</item>
+    <style name="ReactNativeLegalTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:windowBackground">?attr/colorSurface</item>
     </style>
 </resources>

--- a/packages/react-native-legal/android/src/main/res/values/colors.xml
+++ b/packages/react-native-legal/android/src/main/res/values/colors.xml
@@ -1,0 +1,3 @@
+<resources>
+    <color name="surface">#F3EFEE</color>
+</resources>

--- a/packages/react-native-legal/android/src/main/res/values/styles.xml
+++ b/packages/react-native-legal/android/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="ReactNativeLegalTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
-        <item name="android:statusBarColor">#F3EFEE</item>
-        <item name="android:windowBackground">#F3EFEE</item>
+    <style name="ReactNativeLegalTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorSurface</item>
+        <item name="android:windowBackground">?attr/colorSurface</item>
     </style>
 </resources>


### PR DESCRIPTION
`ReactNativeLegalActivity` will automatically switch between dark/light theme based on Android device's theme. This feature is only available [API 29+](https://developer.android.com/develop/ui/views/theming/darktheme), on lower APIs, `ReactNativeLegalActivity` will remain light.

Perhaps `launchLicenseListScreen` function could accept a bool "isDark" argument  to make this programmatic.

See attached video for demonstration.

[dark.webm](https://github.com/user-attachments/assets/16bfe7d8-4c34-4c36-8c0c-a8258b799119)
