### PR TITLE
fix(#41): Plugin always generates Android and ios licenses, even though only Android or ios is setup

### DIFF
--- a/.changeset/fix-41-plugin-throws-exception-when-platform-is-missing.md
+++ b/.changeset/fix-41-plugin-throws-exception-when-platform-is-missing.md
@@ -1,0 +1,5 @@
+---
+'react-native-legal': patch
+---
+
+Fix: plugin throws an error when user uses bare rn app and one of platform is missing

--- a/packages/react-native-legal/bare-plugin/src/index.ts
+++ b/packages/react-native-legal/bare-plugin/src/index.ts
@@ -1,9 +1,14 @@
 import { androidCommand } from './android/androidCommand';
 import { iosCommand } from './ios/iosCommand';
 
-function generateLegal(androidProjectPath: string, iosProjectPath: string) {
-  androidCommand(androidProjectPath);
-  iosCommand(iosProjectPath);
+function generateLegal(androidProjectPath: string | undefined, iosProjectPath: string | undefined) {
+  if (androidProjectPath) {
+    androidCommand(androidProjectPath);
+  }
+
+  if (iosProjectPath) {
+    iosCommand(iosProjectPath);
+  }
 }
 
 export default generateLegal;

--- a/packages/react-native-legal/react-native.config.js
+++ b/packages/react-native-legal/react-native.config.js
@@ -6,7 +6,7 @@ module.exports = {
       func: ([], { project: { android, ios } }, {}) => {
         const generateLegal = require('./bare-plugin/build').default;
 
-        generateLegal(android.sourceDir, ios.sourceDir);
+        generateLegal(android?.sourceDir, ios?.sourceDir);
       },
     },
   ],


### PR DESCRIPTION
This PR resolves the plugin error that occurs when the app uses bare React Native (RN) and only supports a single platform.

Link: #41 