### PR TITLE
refactor: `write*` common logic to accept optional argument defaulting to`generate*` call return value

### DIFF
--- a/packages/shared/src/types/AboutLibrariesLikePackageInfo.ts
+++ b/packages/shared/src/types/AboutLibrariesLikePackageInfo.ts
@@ -1,0 +1,8 @@
+import type { AboutLibrariesLibraryJsonPayload } from './AboutLibrariesLibraryJsonPayload';
+import type { AboutLibrariesLicenseJsonPayload } from './AboutLibrariesLicenseJsonPayload';
+
+export type AboutLibrariesLikePackageInfo = {
+  normalizedPackageName: string;
+  libraryJsonPayload: AboutLibrariesLibraryJsonPayload;
+  licenseJsonPayload: AboutLibrariesLicenseJsonPayload;
+};

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './AggregatedLicensesObj';
 export * from './AboutLibrariesLibraryJsonPayload';
 export * from './AboutLibrariesLicenseJsonPayload';
 export * from './LicensePlistPayload';
+export * from './AboutLibrariesLikePackageInfo';


### PR DESCRIPTION
This PR brings in more flexibility to `write*` functions in the shared package by allowing an optional argument carrying the result of a corresponding `generate*` function call. If the argument is not provided, the appropriate `generate*` function is invoked in the function body.

This PR is a result of the CR in #44 - huge thanks to @mateusz1913 for this idea.

This change is backwards-compatible.