### PR TITLE
fix(ci): update paths trigger condition for lint-ts & E2E workflows to run for pkgs from #44

### DIFF
--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - ".github/workflows/lint-ts.yml"
-      - "packages/react-native-legal/**/*.jsx?"
-      - "packages/react-native-legal/**/*.tsx?"
-      - "examples/**/*.jsx?"
-      - "examples/**/*.tsx?"
+      - '.github/workflows/lint-ts.yml'
+      - 'packages/react-native-legal/**/*.jsx?'
+      - 'packages/react-native-legal/**/*.tsx?'
+      - 'packages/shared/**/*.[tj]sx?'
+      - 'packages/license-kit/**/*.[tj]sx?'
+      - 'examples/**/*.jsx?'
+      - 'examples/**/*.tsx?'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/test-e2e-android.yaml
+++ b/.github/workflows/test-e2e-android.yaml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/test-e2e-android.yaml'
       - 'packages/react-native-legal/**/*.[tj]sx?'
       - 'packages/react-native-legal/android/**'
+      - 'packages/shared/**/*.[tj]sx?'
+      - 'packages/license-kit/**/*.[tj]sx?'
       - 'examples/bare-example/**/*.[tj]sx?'
       - 'examples/bare-example/android/**'
 
@@ -32,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [ 30, 34, 35 ]
+        api-level: [30, 34, 35]
     steps:
       - name: Enable KVM group perms
         run: |
@@ -75,7 +77,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Install example dependencies
-        run:  yarn workspace react-native-legal-bare-example install --frozen-lockfile --immutable
+        run: yarn workspace react-native-legal-bare-example install --frozen-lockfile --immutable
 
       - name: Bundle app
         run: yarn workspace react-native-legal-bare-example build:android

--- a/.github/workflows/test-e2e-ios.yaml
+++ b/.github/workflows/test-e2e-ios.yaml
@@ -8,6 +8,8 @@ on:
       - '.github/workflows/test-e2e-ios.yaml'
       - 'packages/react-native-legal/**/*.[tj]sx?'
       - 'packages/react-native-legal/ios/**'
+      - 'packages/shared/**/*.[tj]sx?'
+      - 'packages/license-kit/**/*.[tj]sx?'
       - 'examples/bare-example/**/*.[tj]sx?'
       - 'examples/bare-example/ios/**'
 
@@ -32,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        simulator: [ 'iPhone 16 Pro (18.5)', 'iPhone SE (3rd generation) (18.0)' ]
+        simulator: ['iPhone 16 Pro (18.5)', 'iPhone SE (3rd generation) (18.0)']
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -48,7 +50,7 @@ jobs:
           target-platform: ios
 
       - name: Install example dependencies
-        run:  yarn workspace react-native-legal-bare-example install --frozen-lockfile --immutable
+        run: yarn workspace react-native-legal-bare-example install --frozen-lockfile --immutable
 
       - name: Cache Pods
         id: cache-pods


### PR DESCRIPTION
This PR introduces a fix to CI workflows to run for changes to JS/TS files in new packages that have been introduced in #44:
- `packages/shared`
- `packages/license-kit`

This applies to the following workflows:
- `lint-ts`
- `test-e2e-android`
- `test-e2e-ios`