### PR TITLE
fix: generateExecCommands to enforce 'npx' commands for non-install commands on the 'npm' tab

### DIFF
--- a/docs/docs/docs/react-native.mdx
+++ b/docs/docs/docs/react-native.mdx
@@ -3,6 +3,7 @@ sidebar_position: 2
 ---
 
 import { PackageManagerTabs, Badge } from '@theme';
+import { generateExecCommands } from '@utils/generateExecCommands';
 
 # React Native Legal
 
@@ -34,11 +35,11 @@ If you are using Expo, you need to add the config plugin to your `app.json` or `
 
 After adding the plugin, rebuild your app using either:
 
-<PackageManagerTabs command="expo prebuild" />
+<PackageManagerTabs command={generateExecCommands('expo prebuild')} />
 
 or
 
-<PackageManagerTabs command="eas build" />
+<PackageManagerTabs command={generateExecCommands('eas build')} />
 
 This will ensure the required native dependencies are included.
 
@@ -50,7 +51,7 @@ This library **cannot be used** in [Expo Go](https://expo.dev/go) because it req
 
 For bare React Native projects, you need to run the CLI plugin to generate and include license data. Run the following command from your project root:
 
-<PackageManagerTabs command="react-native legal-generate" />
+<PackageManagerTabs command={generateExecCommands('react-native legal-generate')} />
 
 This will extract and prepare license metadata for use in your app.
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -14,6 +14,7 @@
     "allowImportingTsExtensions": true,
     "paths": {
       "@components/*": ["./components/*"],
+      "@utils/*": ["./utils/*"],
       "@theme": ["../node_modules/rspress/theme"]
     }
   },

--- a/docs/utils/generateExecCommands.ts
+++ b/docs/utils/generateExecCommands.ts
@@ -1,0 +1,19 @@
+import type { PackageManagerTabs } from 'rspress/theme';
+
+/**
+ * Workaround for the issue with `npx` not being used when the `npm` tab is selected in the `PackageManagerTabs` component.
+ * This function generates the commands for different package managers, ensuring that `npx` is used
+ * when the `npm` tab is selected, while other package managers use their respective commands.
+ *
+ * @param binCommand The command to execute, e.g. `react-native-legal`.
+ * @returns The object for configuring the `PackageManagerTabs` component with commands for different package managers,
+ * taking into account the need to use 'npx' when the 'npm' tab is selected.
+ */
+export function generateExecCommands(binCommand: string) {
+  return {
+    npm: `npx ${binCommand}`,
+    yarn: `yarn ${binCommand}`,
+    pnpm: `pnpm ${binCommand}`,
+    bun: `bun ${binCommand}`,
+  } satisfies React.ComponentProps<typeof PackageManagerTabs>['command'];
+}


### PR DESCRIPTION
This PR fixes the docs pages featuring the `PackageManagerTabs` component for non-`install` commands. The component has apparently not been designed for such commands and while for yarn, pnpm & bun the commands seem to be valid, for npm the binary commands start with `npm`, while they should use `npx` instead.

The props allow specifying commands as a per-package-manager object:
https://github.com/web-infra-dev/rspress/blob/main/packages/theme-default/src/components/PackageManagerTabs/index.tsx#L10-L23

In which case the commands need to explicitly include the executable (in contrast, for a string the executable is prefixed with package manager binary for each manager), which allows us to customize it to use `npx` for npm.