### PR TITLE
fix: multiple version resolution support, fixes #55

### DIFF
--- a/docs/docs/docs/programmatic-usage.mdx
+++ b/docs/docs/docs/programmatic-usage.mdx
@@ -48,7 +48,7 @@ const licensePlistReport = generateLicensePlistNPMOutput(licenses);
 const markdownString = md
   .joinBlocks(
     Object.entries(licenses)
-      .flatMap(([packageName, { version, author, content, description, file, type, url }]) => [
+      .flatMap(([packageKey, { name: packageName, version, author, content, description, file, type, url }]) => [
         md.heading(packageName, { level: 2 }),
         '\n',
         `Version: ${version}<br/>\n`,

--- a/packages/license-kit/src/index.ts
+++ b/packages/license-kit/src/index.ts
@@ -103,17 +103,17 @@ curryCommonScanOptions(
   const strongCopyleftLicensesFound: string[] = [];
   const weakCopyleftLicensesFound: string[] = [];
 
-  for (const [key, value] of Object.entries(licenses)) {
+  for (const value of Object.values(licenses)) {
     STRONG_COPYLEFT_LICENSES.find((license) => {
       if (value.type === license) {
-        strongCopyleftLicensesFound.push(`- ${key}: ${value.type} (${value.file || value.url})`);
+        strongCopyleftLicensesFound.push(`- ${value.name}: ${value.type} (${value.file || value.url})`);
         return true;
       }
     });
 
     WEAK_COPYLEFT_LICENSES.find((license) => {
       if (value.type === license) {
-        weakCopyleftLicensesFound.push(`- ${key}: ${value.type} (${value.file || value.url})`);
+        weakCopyleftLicensesFound.push(`- ${value.name}: ${value.type} (${value.file || value.url})`);
         return true;
       }
     });

--- a/packages/license-kit/src/serializeReport.ts
+++ b/packages/license-kit/src/serializeReport.ts
@@ -28,8 +28,8 @@ export function serializeReport({
       return JSON.stringify(generateAboutLibrariesNPMOutput(licenses), null, 2);
 
     case 'text':
-      return Object.entries(licenses)
-        .map(([packageName, { version, author, content, description, file, type, url }]) =>
+      return Object.values(licenses)
+        .map(({ name: packageName, version, author, content, description, file, type, url }) =>
           [
             `${packageName} (${version})`,
             url ? `URL: ${url}` : '',
@@ -48,8 +48,8 @@ export function serializeReport({
     case 'markdown':
       return md
         .joinBlocks(
-          Object.entries(licenses)
-            .flatMap(([packageName, { version, author, content, description, file, type, url }]) => [
+          Object.values(licenses)
+            .flatMap(({ name: packageName, version, author, content, description, file, type, url }) => [
               '\n',
               md.heading(packageName, { level: 2 }),
               '\n',

--- a/packages/react-native-legal/plugin-utils/src/ios.ts
+++ b/packages/react-native-legal/plugin-utils/src/ios.ts
@@ -59,7 +59,7 @@ export function registerLicensePlistBuildPhaseUtil(
     projectTargetId,
     {
       shellPath: '/bin/sh',
-      shellScript: '${PODS_ROOT}/LicensePlist/license-plist --output-path ./Settings.bundle',
+      shellScript: '${PODS_ROOT}/LicensePlist/license-plist --add-version-numbers --output-path ./Settings.bundle',
     },
   );
   /**

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -46,7 +46,7 @@ const licensePlistReport = generateLicensePlistNPMOutput(licenses);
 const markdownString = md
   .joinBlocks(
     Object.entries(licenses)
-      .flatMap(([packageName, { version, author, content, description, file, type, url }]) => [
+      .flatMap(([packageKey, { name: packageName, version, author, content, description, file, type, url }]) => [
         md.heading(packageName, { level: 2 }),
         '\n',
         `Version: ${version}<br/>\n`,

--- a/packages/shared/src/common.ts
+++ b/packages/shared/src/common.ts
@@ -288,6 +288,7 @@ export function generateAboutLibrariesNPMOutput(licenses: AggregatedLicensesObj)
         tag: '',
         type: licenseObj.type,
         uniqueId: PackageUtils.normalizePackageName(packageKey),
+        website: licenseObj.url,
       };
     })
     .map((jsonPayload) => {
@@ -299,6 +300,7 @@ export function generateAboutLibrariesNPMOutput(licenses: AggregatedLicensesObj)
         name: jsonPayload.name,
         tag: jsonPayload.tag,
         uniqueId: jsonPayload.uniqueId,
+        website: jsonPayload.website,
       };
       const licenseJsonPayload: AboutLibrariesLicenseJsonPayload = {
         content: jsonPayload.content,

--- a/packages/shared/src/types/AboutLibrariesLibraryJsonPayload.ts
+++ b/packages/shared/src/types/AboutLibrariesLibraryJsonPayload.ts
@@ -6,4 +6,5 @@ export type AboutLibrariesLibraryJsonPayload = {
   name: string;
   tag: string;
   uniqueId: string;
+  website: string | undefined;
 };

--- a/packages/shared/src/types/AboutLibrariesLikePackageInfo.ts
+++ b/packages/shared/src/types/AboutLibrariesLikePackageInfo.ts
@@ -2,7 +2,7 @@ import type { AboutLibrariesLibraryJsonPayload } from './AboutLibrariesLibraryJs
 import type { AboutLibrariesLicenseJsonPayload } from './AboutLibrariesLicenseJsonPayload';
 
 export type AboutLibrariesLikePackageInfo = {
-  normalizedPackageName: string;
+  normalizedPackageNameWithVersion: string;
   libraryJsonPayload: AboutLibrariesLibraryJsonPayload;
   licenseJsonPayload: AboutLibrariesLicenseJsonPayload;
 };

--- a/packages/shared/src/types/AggregatedLicensesObj.ts
+++ b/packages/shared/src/types/AggregatedLicensesObj.ts
@@ -1,3 +1,7 @@
 import type { LicenseObj } from './LicenseObj';
 
+/**
+ * Mapping from package keys in format `<package-name>/<package-version>` to license objects.
+ * @see {@link LicenseObj}
+ */
 export type AggregatedLicensesObj = Record<string, LicenseObj>;

--- a/packages/shared/src/types/DependencyType.ts
+++ b/packages/shared/src/types/DependencyType.ts
@@ -1,0 +1,3 @@
+type BaseDependencyType = 'dependency' | 'devDependency' | 'optionalDependency' | 'peerDependency';
+
+export type DependencyType = BaseDependencyType | `transitive${Capitalize<BaseDependencyType>}`;

--- a/packages/shared/src/types/LicenseObj.ts
+++ b/packages/shared/src/types/LicenseObj.ts
@@ -1,10 +1,34 @@
+import type { DependencyType } from './DependencyType';
+import type { ScanPackageCallContext } from './ScanPackageCallContext';
+
 export type LicenseObj = {
+  /** Package name */
   name: string;
+
+  /** Package author */
   author?: string;
+
+  /** Package license contents */
   content?: string;
+
+  /** Package description */
   description?: string;
+
+  /** License file path */
   file?: string;
+
+  /** License type */
   type?: string;
+
+  /** Package repository URL */
   url?: string;
+
+  /** The resolved version that was actually installed */
   version: string;
-};
+
+  /** The source of how this package has been introduced to the dependency tree */
+  dependencyType: DependencyType;
+
+  /** The required version specified in package.json */
+  requiredVersion: string;
+} & Pick<ScanPackageCallContext, 'parentPackageName'>;

--- a/packages/shared/src/types/LicenseObj.ts
+++ b/packages/shared/src/types/LicenseObj.ts
@@ -1,4 +1,5 @@
 export type LicenseObj = {
+  name: string;
   author?: string;
   content?: string;
   description?: string;

--- a/packages/shared/src/types/ScanPackageCallContext.ts
+++ b/packages/shared/src/types/ScanPackageCallContext.ts
@@ -1,0 +1,30 @@
+import type { DependencyType } from './DependencyType';
+
+export type ScanPackageCallContext = {
+  /** Information on what is the source of the dependency on the package to be scanned */
+  dependencyType: DependencyType;
+
+  /**
+   * The name of the package that introduced the package to be scanned as a dependency (of any type);
+   * undefined if the package to be scanned is a dependency of the root package
+   */
+  parentPackageName?: string;
+
+  /**
+   * The installation directory of the package that introduced the package to be scanned as a dependency (of any type);
+   * undefined if the package to be scanned is a dependency of the root package
+   */
+  parentPackageRoot?: string;
+
+  /**
+   * The required version, as specified in package.json
+   * of the package that introduced the package to be scanned as a dependency (of any type)
+   */
+  parentPackageRequiredVersion?: string;
+
+  /**
+   * The resolved (actually installed by the package manager) version
+   * of the package that introduced the package to be scanned as a dependency (of any type)
+   */
+  parentPackageResolvedVersion?: string;
+};

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -5,3 +5,5 @@ export * from './AboutLibrariesLicenseJsonPayload';
 export * from './LicensePlistPayload';
 export * from './AboutLibrariesLikePackageInfo';
 export * from './ScanPackageOptions';
+export * from './ScanPackageCallContext';
+export * from './DependencyType';


### PR DESCRIPTION
This PR brings in a few improvements:
- fixes #55 by adding support for scanning of nested dependencies (for more context, please read #55)
- fixes bug on Android which caused all items on the license list that were generated from JS not to have a link (`website` property)
- enables the iOS screen to show version numbers of the dependencies (adds `--add-version-numbers` flag to the appropriate build step)
- adds more details to scan package info (`LicenseObj` type) to give more flexibility to consume the results
- updates the docstrings

These changes are not backwards-compatible w.r.t. the internal `scanPackage` function (which is not a breaking change for external users), **however** they also change the internal representation format of the scan result (return value of `scanDependencies`), which **is a breaking change**: the keys of this object are now not the names of the package, but unique keys in the format of `<package name>/<package version>`. Each package may now be present more than 1 time in this mapping, if it is installed under multiple versions which may differ in e.g. the license.
Also, as mentioned above, the package info objects will have more keys (additional properties).