### PR TITLE
fix(docs): missing iosProjectPath in sample code using generateLicensePlistNPMOutput

### DIFF
--- a/docs/docs/docs/programmatic-usage.mdx
+++ b/docs/docs/docs/programmatic-usage.mdx
@@ -49,7 +49,7 @@ const licenses = scanDependencies(packageJsonPath, optionsFactory);
 const aboutLibrariesCompatibleReport = generateAboutLibrariesNPMOutput(licenses);
 
 // generate LicensePlist-compatible metadata
-const licensePlistReport = generateLicensePlistNPMOutput(licenses);
+const licensePlistReport = generateLicensePlistNPMOutput(licenses, iosProjectPath);
 
 // generate a Markdown report
 const markdownString = md

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -40,7 +40,7 @@ const licenses = scanDependencies(packageJsonPath, optionsFactory);
 const aboutLibrariesCompatibleReport = generateAboutLibrariesNPMOutput(licenses);
 
 // generate LicensePlist-compatible metadata
-const licensePlistReport = generateLicensePlistNPMOutput(licenses);
+const licensePlistReport = generateLicensePlistNPMOutput(licenses, iosProjectPath);
 
 // generate a Markdown report
 const markdownString = md


### PR DESCRIPTION
This PR fixes docs parts where the 2nd required argument to `generateLicensePlistNPMOutput` calls is missing.