### PR TITLE
fix(test): allow partially-visible RN entry on license list in E2E tests

### DIFF
--- a/.github/workflows/test-e2e-android.yaml
+++ b/.github/workflows/test-e2e-android.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/test-e2e-android.yaml'
+      - 'examples/bare-example/e2e/checkLicenses/android.yaml'
       - 'packages/react-native-legal/**/*.[tj]sx?'
       - 'packages/react-native-legal/android/**'
       - 'packages/shared/**/*.[tj]sx?'

--- a/.github/workflows/test-e2e-ios.yaml
+++ b/.github/workflows/test-e2e-ios.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/test-e2e-ios.yaml'
+      - 'examples/bare-example/e2e/checkLicenses/ios.yaml'
       - 'packages/react-native-legal/**/*.[tj]sx?'
       - 'packages/react-native-legal/ios/**'
       - 'packages/shared/**/*.[tj]sx?'

--- a/examples/bare-example/e2e/checkLicenses/android.yaml
+++ b/examples/bare-example/e2e/checkLicenses/android.yaml
@@ -26,6 +26,7 @@ tags:
     timeout: 190000
     centerElement: true
     speed: 70
+    visibilityPercentage: 75
 - takeScreenshot: 'e2e_results/react-native_list_element'
 - assertVisible:
     text: 'Facebook'

--- a/examples/bare-example/e2e/checkLicenses/ios.yaml
+++ b/examples/bare-example/e2e/checkLicenses/ios.yaml
@@ -24,6 +24,7 @@ tags:
     direction: 'DOWN'
     timeout: 100000
     speed: 80
+    visibilityPercentage: 75
 - takeScreenshot: 'e2e_results/react-native_list_element'
 - tapOn: 'react-native (.*)'
 - takeScreenshot: 'e2e_results/react-native_entry'


### PR DESCRIPTION
This PR:
- allows a 75%-visible RN entry in E2E tests to improve stability
- fixes CI E2E tests not being re-run upon changes to maestro workflow files