### PR TITLE
chore: setup nohoist for docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,9 @@
   "name": "docs",
   "version": "1.0.0",
   "private": true,
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  },
   "scripts": {
     "build": "rspress build",
     "check": "biome check --write",


### PR DESCRIPTION
### Summary

Hoisting deps by yarn was causing issues for doc setup, this PR adds a `nohoist` rule for docs which prevents hoisting and resolves the issue.