### PR TITLE
test: add test for exclusion of private package from report

### DIFF
--- a/docs/docs/docs/programmatic-usage.mdx
+++ b/docs/docs/docs/programmatic-usage.mdx
@@ -114,6 +114,14 @@ This tool (and in turn, the CLI and RN plugins) do not support `file:` specified
 If you would like to have support for this, please start a discussion on Github.
 :::
 
+#### Private packages
+
+All private packages (i.e., packages that have a `private: true` field in their `package.json`) are excluded from the scan. All their dependencies (all kinds of dependencies) also are **not included** in the scan / report. Therefore, all the tooling ignores private packages & their dependencies.
+
+:::warning
+If you are using a private package that introduces dependencies to your bundle / program, remember it itself & its dependencies won't be included.
+:::
+
 ### Default `scanOptionsFactory` value
 
 The default value for the optional `scanOptionsFactory` parameter in `scanPackage` & `scanDependencies` functions is set to the following:

--- a/examples/node-example/__tests__/report.spec.ts
+++ b/examples/node-example/__tests__/report.spec.ts
@@ -21,7 +21,10 @@ import {
   optionalDependencies as optionalDependenciesObj,
 } from '../package.json';
 
-const dependencies = dependencyMappingToCorrespondingKey(dependenciesObj);
+// do not expect the private test package to be in the assertions baseline, it shall be excluded
+const dependencies = dependencyMappingToCorrespondingKey(dependenciesObj).filter(
+  (dep) => dep !== '@callstack/example-private-package@workspace:*',
+);
 const devDependencies = dependencyMappingToCorrespondingKey(devDependenciesObj);
 const optionalDependencies = dependencyMappingToCorrespondingKey(optionalDependenciesObj);
 const licenseKitDependencies = dependencyMappingToCorrespondingKey(licenseKitDependenciesObj);
@@ -78,6 +81,12 @@ describe('license-kit report', () => {
     expect(Object.keys(json).toSorted()).toEqual(
       Array.from(new Set([...dependencies, ...optionalDependencies, ...devDependencies])).toSorted(),
     );
+  });
+
+  it("does not include private packages' licenses", async () => {
+    const json = await runReportCommandForJsonOutput();
+
+    expect(Object.keys(json).toSorted()).not.toIncludeAllMembers(['@callstack/example-private-package']);
   });
 
   it('with root-only dev deps and with transitive dependencies of workspace-specifier-only dependencies', async () => {

--- a/examples/node-example/package.json
+++ b/examples/node-example/package.json
@@ -9,6 +9,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@callstack/example-private-package": "workspace:*",
     "dhtmlx-gantt": "9.0.11",
     "is-even": "1.0.0",
     "mariadb": "3.4.2",

--- a/examples/packages/example-private-package/README.md
+++ b/examples/packages/example-private-package/README.md
@@ -1,0 +1,3 @@
+# @callstack/example-private-package
+
+This is a test private package (`private: true`) for the needs of example tester projects in this monorepository to depend on, to test that the private package's license is not being included in the report.

--- a/examples/packages/example-private-package/package.json
+++ b/examples/packages/example-private-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@callstack/example-private-package",
+  "packageManager": "yarn@3.6.1",
+  "private": true
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "packages": [
       "packages/*",
       "docs",
-      "examples/*"
+      "examples/*",
+      "examples/packages/*"
     ]
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4177,6 +4177,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@callstack/example-private-package@workspace:*, @callstack/example-private-package@workspace:examples/packages/example-private-package":
+  version: 0.0.0-use.local
+  resolution: "@callstack/example-private-package@workspace:examples/packages/example-private-package"
+  languageName: unknown
+  linkType: soft
+
 "@callstack/licenses@^0.2.1, @callstack/licenses@workspace:packages/licenses-api":
   version: 0.0.0-use.local
   resolution: "@callstack/licenses@workspace:packages/licenses-api"
@@ -15702,6 +15708,7 @@ __metadata:
     "@babel/core": 7.27.4
     "@babel/preset-env": 7.27.2
     "@babel/preset-typescript": 7.27.1
+    "@callstack/example-private-package": "workspace:*"
     "@types/jest": 29.5.5
     babel-jest: 29.7.0
     chartjs-plugin-dragdata: 2.3.1


### PR DESCRIPTION
This PR introduces a new unit test case for asserting that a `private: true` package is not being included in the report.
It also updates the docs to describe the behaviour with private packages for clarity.