### PR TITLE
feat(#10): initial basic web support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ project.xcworkspace
 build/
 packages/*/lib/
 packages/*/build/
+.rnlegal/
 
 # Expo example
 examples/expo-example/android

--- a/examples/expo-example/index.js
+++ b/examples/expo-example/index.js
@@ -1,3 +1,4 @@
+import '@expo/metro-runtime';
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/examples/expo-example/package.json
+++ b/examples/expo-example/package.json
@@ -7,18 +7,22 @@
     "expo": "expo",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web",
+    "web": "react-native-legal && expo start --web",
+    "react-native-legal": "react-native-legal",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@expo/metro-runtime": "~4.0.1",
     "expo": "~52.0.36",
     "expo-build-properties": "~0.13.2",
     "expo-splash-screen": "~0.29.22",
     "expo-status-bar": "~2.0.1",
     "react": "18.3.1",
+    "react-dom": "18.3.1",
     "react-native": "0.76.7",
     "react-native-legal": "workspace:*",
-    "react-native-legal-common-example-ui": "workspace:*"
+    "react-native-legal-common-example-ui": "workspace:*",
+    "react-native-web": "~0.19.13"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/packages/react-native-legal/bin/index.js
+++ b/packages/react-native-legal/bin/index.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { scanDependencies } = require('@callstack/licenses');
+
+const repoRootPath = path.resolve(process.cwd());
+const packageJsonPath = path.join(repoRootPath, 'package.json');
+
+if (!fs.existsSync(packageJsonPath)) {
+  console.error(`package.json not found at ${packageJsonPath}`);
+  process.exit(1);
+}
+
+const licenses = scanDependencies(packageJsonPath);
+
+const payload = Object.entries(licenses)
+  .map(([packageKey, licenseObj]) => {
+    return {
+      name: licenseObj.name,
+      version: licenseObj.version,
+      content: licenseObj.content ?? licenseObj.type ?? 'UNKNOWN',
+      packageKey,
+      ...(licenseObj.url && { source: licenseObj.url }),
+    };
+  })
+  .toSorted((first, second) => {
+    if (!first.version || !second.version) {
+      return first.name > second.name;
+    }
+
+    if (first.name !== second.name) {
+      return first.name > second.name ? 1 : -1;
+    }
+
+    const [firstMajor, firstMinor, firstPatch] = first.version.split('.').filter(Boolean);
+    const [secondMajor, secondMinor, secondPatch] = second.version.split('.').filter(Boolean);
+
+    return `${first.name}.${firstMajor.padStart(10, '0')}.${(firstMinor ?? '0').padStart(10, '0')}.${(
+      firstPatch ?? '0'
+    ).padStart(10, '0')}` >
+      `${second.name}.${secondMajor.padStart(10, '0')}.${(secondMinor ?? '0').padStart(10, '0')}.${(
+        secondPatch ?? '0'
+      ).padStart(10, '0')}`
+      ? 1
+      : -1;
+  });
+
+const rnLegalConfigPath = path.join(__dirname, '..', '.rnlegal');
+
+if (!fs.existsSync(rnLegalConfigPath)) {
+  fs.mkdirSync(rnLegalConfigPath);
+}
+
+const rnLegalConfigLibrariesPath = path.join(rnLegalConfigPath, 'libraries.json');
+
+fs.writeFileSync(rnLegalConfigLibrariesPath, JSON.stringify(payload), { encoding: 'utf-8' });
+
+console.log(`✅ Output written to ${rnLegalConfigLibrariesPath}`);

--- a/packages/react-native-legal/package.json
+++ b/packages/react-native-legal/package.json
@@ -12,6 +12,7 @@
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",
+  "bin": "./bin/index.js",
   "react-native": "src/index",
   "source": "src/index",
   "repository": {

--- a/packages/react-native-legal/src/ReactNativeLegal.web.ts
+++ b/packages/react-native-legal/src/ReactNativeLegal.web.ts
@@ -1,0 +1,95 @@
+import type { LibrariesResult } from './NativeReactNativeLegal';
+
+export const ReactNativeLegal = {
+  getLibrariesAsync: () => {
+    const payload = require(`react-native-legal/.rnlegal/libraries.json`);
+
+    return Promise.resolve<LibrariesResult>({
+      data: payload.map((library: any) => ({
+        id: library.packageKey,
+        name: library.packageKey,
+        licenses: [{ licenseContent: library.content }],
+      })),
+    });
+  },
+  launchLicenseListScreen: (licenseHeaderText?: string) => {
+    const payload = require(`react-native-legal/.rnlegal/libraries.json`);
+
+    const main = document.createElement('main');
+
+    main.style.display = 'flex';
+    main.style.alignSelf = 'stretch';
+    main.style.flex = '1';
+    main.style.flexDirection = 'column';
+    main.style.overflow = 'scroll';
+    main.style.width = '100%';
+
+    const closeBtn = document.createElement('button');
+
+    closeBtn.innerText = 'Close';
+
+    const headerContainer = document.createElement('header');
+
+    headerContainer.style.display = 'flex';
+    headerContainer.style.flexDirection = 'row';
+    headerContainer.style.alignItems = 'center';
+    headerContainer.style.justifyContent = 'space-between';
+    headerContainer.appendChild(closeBtn);
+
+    main.appendChild(headerContainer);
+
+    if (licenseHeaderText) {
+      const header = document.createElement('h1');
+
+      header.innerText = licenseHeaderText;
+
+      headerContainer.insertBefore(header, closeBtn);
+    } else {
+      headerContainer.style.flexDirection = 'row-reverse';
+    }
+
+    payload.forEach((library: any) => {
+      const summary = document.createElement('summary');
+
+      summary.style.fontSize = '20px';
+      summary.style.margin = '10px 0px';
+      summary.innerText = library.packageKey;
+
+      const content = document.createElement('p');
+
+      content.innerText = library.content;
+
+      const details = document.createElement('details');
+
+      details.appendChild(summary);
+      details.appendChild(content);
+
+      main.appendChild(details);
+    });
+
+    const dialog = document.createElement('dialog');
+
+    dialog.id = 'react-native-legal-dialog';
+    dialog.style.height = '90%';
+    dialog.style.width = '90%';
+    dialog.appendChild(main);
+
+    document.querySelector('body')?.appendChild(dialog);
+
+    closeBtn.addEventListener(
+      'click',
+      () => {
+        document.querySelector('body')?.removeChild(dialog);
+      },
+      { once: true },
+    );
+    dialog.addEventListener(
+      'close',
+      () => {
+        document.querySelector('body')?.removeChild(dialog);
+      },
+      { once: true },
+    );
+    dialog.showModal();
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3930,6 +3930,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.18.6":
+  version: 7.27.6
+  resolution: "@babel/runtime@npm:7.27.6"
+  checksum: 3f7b879df1823c0926bd5dbc941c62f5d60faa790c1aab9758c04799e1f04ee8d93553be9ec059d4e5882f19fe03cbe8933ee4f46212dced0f6d8205992c9c9a
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.25.0, @babel/runtime@npm:^7.5.5":
   version: 7.26.9
   resolution: "@babel/runtime@npm:7.26.9"
@@ -5205,6 +5212,15 @@ __metadata:
     postcss: ~8.4.32
     resolve-from: ^5.0.0
   checksum: 3dc22f8cb388a310a9a65123ef25e18d916a375e77146747166af04e744af83d3b5f7f12d4cd4d53449e10c7ab7eeb9aa87de325827f1c4e25ff3a14bc3d8ffd
+  languageName: node
+  linkType: hard
+
+"@expo/metro-runtime@npm:~4.0.1":
+  version: 4.0.1
+  resolution: "@expo/metro-runtime@npm:4.0.1"
+  peerDependencies:
+    react-native: "*"
+  checksum: 04d0bd0b3ca1221f29dabbe8bee1cc4d2e7cb086b728f3edf4d477e230a60b87a8eb828a09618022988009a71c2f85207fb1dec929d324601fccf4b5c3202e8e
   languageName: node
   linkType: hard
 
@@ -6538,6 +6554,13 @@ __metadata:
   version: 0.76.7
   resolution: "@react-native/normalize-colors@npm:0.76.7"
   checksum: 4840d1f3852d908520aa77733dae07bd7bcfaa393e0245ea74716246d626785a6abe3add9c4975cbdabc45f5eaf56bbb133fd63e471b48e975a07ca5c346c9bb
+  languageName: node
+  linkType: hard
+
+"@react-native/normalize-colors@npm:^0.74.1":
+  version: 0.74.89
+  resolution: "@react-native/normalize-colors@npm:0.74.89"
+  checksum: df62772f029dd132d3061a8ee7f90b6aaf5c525bb7e33c22908249daffa42995cddd91adc790ec9ce701636c14eeafc1809a9d0d879e3f8c71c9f340145abfce
   languageName: node
   linkType: hard
 
@@ -9946,6 +9969,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-in-js-utils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "css-in-js-utils@npm:3.1.0"
+  dependencies:
+    hyphenate-style-name: ^1.0.3
+  checksum: 066318e918c04a5e5bce46b38fe81052ea6ac051bcc6d3c369a1d59ceb1546cb2b6086901ab5d22be084122ee3732169996a3dfb04d3406eaee205af77aec61b
+  languageName: node
+  linkType: hard
+
 "cssom@npm:^0.5.0":
   version: 0.5.0
   resolution: "cssom@npm:0.5.0"
@@ -12221,6 +12253,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-loops@npm:^1.1.3":
+  version: 1.1.4
+  resolution: "fast-loops@npm:1.1.4"
+  checksum: 8031a20f465ef35ac4ad98258470250636112d34f7e4efcb4ef21f3ced99df95a1ef1f0d6943df729a1e3e12a9df9319f3019df8cc1a0e0ed5a118bd72e505f9
+  languageName: node
+  linkType: hard
+
 "fast-xml-parser@npm:^4.4.1":
   version: 4.5.3
   resolution: "fast-xml-parser@npm:4.5.3"
@@ -12266,7 +12305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fbjs@npm:^3.0.0":
+"fbjs@npm:^3.0.0, fbjs@npm:^3.0.4":
   version: 3.0.5
   resolution: "fbjs@npm:3.0.5"
   dependencies:
@@ -13620,6 +13659,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hyphenate-style-name@npm:^1.0.3":
+  version: 1.1.0
+  resolution: "hyphenate-style-name@npm:1.1.0"
+  checksum: b9ed74e29181d96bd58a2d0e62fc4a19879db591dba268275829ff0ae595fcdf11faafaeaa63330a45c3004664d7db1f0fc7cdb372af8ee4615ed8260302c207
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -13754,6 +13800,16 @@ __metadata:
   version: 0.2.4
   resolution: "inline-style-parser@npm:0.2.4"
   checksum: 5df20a21dd8d67104faaae29774bb50dc9690c75bc5c45dac107559670a5530104ead72c4cf54f390026e617e7014c65b3d68fb0bb573a37c4d1f94e9c36e1ca
+  languageName: node
+  linkType: hard
+
+"inline-style-prefixer@npm:^6.0.1":
+  version: 6.0.4
+  resolution: "inline-style-prefixer@npm:6.0.4"
+  dependencies:
+    css-in-js-utils: ^3.1.0
+    fast-loops: ^1.1.3
+  checksum: caf7a75d18acbedc7e3b8bfac17563082becd2df6b65accad964a6afdf490329b42315c37fe65ba0177cc10fd32809eb40d62aba23a0118c74d87d4fc58defa2
   languageName: node
   linkType: hard
 
@@ -16465,6 +16521,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"memoize-one@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "memoize-one@npm:6.0.0"
+  checksum: f185ea69f7cceae5d1cb596266dcffccf545e8e7b4106ec6aa93b71ab9d16460dd118ac8b12982c55f6d6322fcc1485de139df07eacffaae94888b9b3ad7675f
+  languageName: node
+  linkType: hard
+
 "meow@npm:^8.0.0":
   version: 8.1.2
   resolution: "meow@npm:8.1.2"
@@ -18493,6 +18556,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-value-parser@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "postcss-value-parser@npm:4.2.0"
+  checksum: 819ffab0c9d51cf0acbabf8996dffbfafbafa57afc0e4c98db88b67f2094cb44488758f06e5da95d7036f19556a4a732525e84289a425f4f6fd8e412a9d7442f
+  languageName: node
+  linkType: hard
+
 "postcss@npm:~8.4.32":
   version: 8.4.49
   resolution: "postcss@npm:8.4.49"
@@ -18762,6 +18832,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dom@npm:18.3.1":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
+  dependencies:
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.2
+  peerDependencies:
+    react: ^18.3.1
+  checksum: 298954ecd8f78288dcaece05e88b570014d8f6dce5db6f66e6ee91448debeb59dcd31561dddb354eee47e6c1bb234669459060deb238ed0213497146e555a0b9
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^19.1.0":
   version: 19.1.0
   resolution: "react-dom@npm:19.1.0"
@@ -18877,15 +18959,18 @@ __metadata:
   resolution: "react-native-legal-expo-example@workspace:examples/expo-example"
   dependencies:
     "@babel/core": ^7.25.2
+    "@expo/metro-runtime": ~4.0.1
     "@types/react": ~18.3.12
     expo: ~52.0.36
     expo-build-properties: ~0.13.2
     expo-splash-screen: ~0.29.22
     expo-status-bar: ~2.0.1
     react: 18.3.1
+    react-dom: 18.3.1
     react-native: 0.76.7
     react-native-legal: "workspace:*"
     react-native-legal-common-example-ui: "workspace:*"
+    react-native-web: ~0.19.13
   languageName: unknown
   linkType: soft
 
@@ -18910,8 +18995,29 @@ __metadata:
   peerDependenciesMeta:
     expo:
       optional: true
+  bin:
+    react-native-legal: ./bin/index.js
   languageName: unknown
   linkType: soft
+
+"react-native-web@npm:~0.19.13":
+  version: 0.19.13
+  resolution: "react-native-web@npm:0.19.13"
+  dependencies:
+    "@babel/runtime": ^7.18.6
+    "@react-native/normalize-colors": ^0.74.1
+    fbjs: ^3.0.4
+    inline-style-prefixer: ^6.0.1
+    memoize-one: ^6.0.0
+    nullthrows: ^1.1.1
+    postcss-value-parser: ^4.2.0
+    styleq: ^0.1.3
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 15077f88204cb980203b8e3784c092c8c25c972bf281db43fd4ccc9696b603380a49f5289fb9a742daddd8e7599baab5798a1f1c857bdd634add827bc39fd8d8
+  languageName: node
+  linkType: hard
 
 "react-native@npm:0.76.7":
   version: 0.76.7
@@ -21054,6 +21160,13 @@ __metadata:
   dependencies:
     inline-style-parser: 0.2.4
   checksum: a89e229161a56c53e28d1b91dcdc902f482f577db8b13741d3f056df7df0fbff4ecb44e06e32960f11c3a477b26f056e889a223bef6bc72b162935c5e4828145
+  languageName: node
+  linkType: hard
+
+"styleq@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "styleq@npm:0.1.3"
+  checksum: 14a8d23abd914166a9b4bd04ed753bd91363f0e029ee4a94ec2c7dc37d3213fe01fceee22dc655288da3ae89f5dc01cec42d5e2b58478b0dea33bf5bdf509be1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #10 

- added react-native-web to expo example
- created simple script to generate libraries payload using `@callstack/licenses`
- implemented basic support for `getLibrariesAsync` and `launchLicenseListScreen`