### PR TITLE
Fix typo in documentation's code

### DIFF
--- a/docs/docs/docs/react-native.mdx
+++ b/docs/docs/docs/react-native.mdx
@@ -103,7 +103,7 @@ function MyComponent() {
 
   React.useEffect(() => {
     async function getLibraries() {
-      const result = = await ReactNativeLegal.getLibrariesAsync();
+      const result = await ReactNativeLegal.getLibrariesAsync();
 
       setLibraries(result.data);
     }


### PR DESCRIPTION
There's a simple typo in the documentation for the "Retrieving licenses metadata and custom UI" section.