### PR TITLE
chore: changeset for `@callstack/licenses`

### DIFF
--- a/.changeset/chubby-poems-melt.md
+++ b/.changeset/chubby-poems-melt.md
@@ -1,0 +1,5 @@
+---
+'@callstack/licenses': minor
+---
+
+Change parentPackage to parentPackages array, rename exported types for brevity, separate exports for node & web environments


### PR DESCRIPTION
The purpose of this PR is to release the `@callstack/licenses` changes from #79 .