### PR TITLE
fix(docs): add missing extension for contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ You can use the `@callstack/licenses` package to access the core functionalities
 
 ## Contributing
 
-See the [contributing guide](./CONTRIBUTING) to learn how to contribute to the repository and the development workflow.
+See the [contributing guide](./CONTRIBUTING.md) to learn how to contribute to the repository and the development workflow.
 
 ## Acknowledgements
 


### PR DESCRIPTION
Fixes an issue where accessing the contributing guide would result in a 404 error.
This PR adds the missing file extension(`.md`)