### PR TITLE
fix(android): Resolve type mismatch error in ReactNativeLegalModuleImpl.kt

### DIFF
--- a/packages/react-native-legal/android/src/main/java/com/reactnativelegal/ReactNativeLegalModuleImpl.kt
+++ b/packages/react-native-legal/android/src/main/java/com/reactnativelegal/ReactNativeLegalModuleImpl.kt
@@ -31,7 +31,8 @@ object ReactNativeLegalModuleImpl {
             cachedData = retrieveLibrariesArray(reactContext)
         }
 
-        return Arguments.createMap().apply { putArray("data", Arguments.fromList(cachedData)) }
+        val libraries = cachedData ?: emptyList<Bundle>()
+        return Arguments.createMap().apply { putArray("data", Arguments.fromList(libraries)) }
     }
 
     private fun retrieveLibrariesArray(reactContext: ReactApplicationContext): List<Bundle>? {


### PR DESCRIPTION
PR #33

Argument type mismatch error occurred when passing nullable `List<Bundle>?` to `Arguments.fromList()` expecting non-null.
This PR fixed it by adding explicit empty list fallback with `emptyList()`

### Environment
 - Kotlin: 2.2.0
 - Android Gradle Plugin: 8.11.1