### PR TITLE
chore: changeset for RN plugin

### DIFF
--- a/.changeset/true-facts-tell.md
+++ b/.changeset/true-facts-tell.md
@@ -1,0 +1,5 @@
+---
+'react-native-legal': minor
+---
+
+Upgraded to `@callstack/licenses@0.3.0`


### PR DESCRIPTION
The purpose of this PR is to release the `react-native-legal` changes from #79 .