### PR TITLE
chore: move from legacy npm lefthook package and change from pre-commit to pre-push

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,6 @@ plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-postinstall.cjs
     spec: "https://raw.githubusercontent.com/gravitywelluk/yarn-plugin-postinstall/master/bundles/%40yarnpkg/plugin-postinstall.js"
 
-postinstall: npx -c 'lefthook install' && yarn build:library
+postinstall: npx -c 'lefthook install' && yarn build:library && yarn build:visualizer
 
 yarnPath: .yarn/releases/yarn-3.6.1.cjs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,7 @@ We use [changesets](https://github.com/changesets/changesets) to make it easier 
 The `package.json` file contains various scripts for common tasks:
 
 - `yarn build:library`: compile the library code with babel.
+- `yarn build:visualizer`: compile the Next.js visualizer code.
 - `yarn lint:js`: lint files with ESLint.
 - `yarn typescript`: type-check files with TypeScript.
 - `yarn lint:android`: lint Kotlin files.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,41 +1,48 @@
-pre-commit:
+pre-push:
   piped: true
   commands:
     lint-js:
       # Run ESLint for root ESLint config JS/TS files if any of them are staged
-      files: git diff --name-only --cached
+      files: git diff --name-only --cached origin/main
       glob: '*.{js,ts,jsx,tsx}'
       run: yarn lint:js
       exclude:
         - 'packages/visualizer/**'
     lint-js-visualizer:
       # Run ESLint for visualizer ESLint config JS/TS files if any of them are staged
-      files: git diff --name-only --cached
-      glob: 'packages/visualizer/**/*.{js,ts,jsx,tsx}'
+      files: git diff --name-only --cached origin/main
+      glob: 'packages/visualizer/*.{js,ts,jsx,tsx}'
       run: yarn workspace @callstack/license-kit-visualizer lint
     lint-docs:
       # Run biome linter for docs files if any of them are staged
-      files: git diff --name-only --cached
-      glob: 'docs/**/*.{md,mdx,js,ts,jsx,tsx}'
+      files: git diff --name-only --cached origin/main
+      glob: 'docs/*.{md,mdx,js,ts,jsx,tsx}'
       run: yarn lint:docs
     typescript:
       # Run type-checking for TS files if any of them are staged
-      files: git diff --name-only --cached
+      files: git diff --name-only --cached origin/main
       glob: '*.{js,ts,jsx,tsx}'
       run: yarn typescript
+      exclude:
+        - 'packages/visualizer/**'
+    typescript-visualizer:
+      # Run type-checking for TS files if any of them are staged
+      files: git diff --name-only --cached origin/main
+      glob: 'packages/visualizer/*.{js,ts,jsx,tsx}'
+      run: yarn workspace @callstack/license-kit-visualizer build
     lint-android:
       # Run linter for Kotlin files if any of them are staged
-      files: git diff --name-only --cached
+      files: git diff --name-only --cached origin/main
       glob: '*.{kt,kts}'
       run: yarn lint:android
     lint-objc:
       # Run linter for ObjC files if any of them are staged
-      files: git diff --name-only --cached
+      files: git diff --name-only --cached origin/main
       glob: '*.{h,m,mm}'
       run: yarn lint:objc
     lint-swift:
       # Run linter for Swift files if any of them are staged
-      files: git diff --name-only --cached
+      files: git diff --name-only --cached origin/main
       glob: '*.{swift}'
       run: yarn lint:swift
 commit-msg:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     ]
   },
   "scripts": {
-    "build:library": "yarn workspace @callstack/licenses build && yarn workspace react-native-legal build-plugins && yarn workspace license-kit build-library && yarn workspace react-native-legal build-library && yarn workspace @callstack/license-kit-visualizer build",
+    "build:library": "yarn workspace @callstack/licenses build && yarn workspace react-native-legal build-plugins && yarn workspace license-kit build-library && yarn workspace react-native-legal build-library",
+    "build:visualizer": "yarn workspace @callstack/license-kit-visualizer build",
     "lint:js": "eslint \"**/*.{js,ts,tsx}\"",
     "lint:docs": "yarn workspace docs check",
     "typescript": "yarn build:library && tsc --noEmit -p examples/bare-example/tsconfig.json && tsc --noEmit -p examples/expo-example/tsconfig.json",
@@ -40,12 +41,12 @@
     "@changesets/changelog-github": "^0.5.1",
     "@changesets/cli": "^2.28.1",
     "@commitlint/config-conventional": "17.6.6",
-    "@evilmartians/lefthook": "1.12.2",
     "commitlint": "17.6.6",
     "eslint": "^8.46.0",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-prettier": "^5.5.3",
     "expo": "~52.0.36",
+    "lefthook": "1.12.2",
     "prettier": "^3.6.2",
     "typescript": "^5.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5172,16 +5172,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@evilmartians/lefthook@npm:1.12.2":
-  version: 1.12.2
-  resolution: "@evilmartians/lefthook@npm:1.12.2"
-  bin:
-    lefthook: bin/index.js
-  checksum: 99d29d4c700bb22b75838603589896a5368b0512a813df9cb6d807cf2317301cac7154dd53c2714d5a466ee5d3b74166140736201e84bbec29d05b6006c7030f
-  conditions: (os=darwin | os=linux | os=win32) & (cpu=x64 | cpu=arm64 | cpu=ia32)
-  languageName: node
-  linkType: hard
-
 "@expo/bunyan@npm:^4.0.0":
   version: 4.0.0
   resolution: "@expo/bunyan@npm:4.0.0"
@@ -17708,6 +17698,117 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lefthook-darwin-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-darwin-arm64@npm:1.12.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-darwin-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-darwin-x64@npm:1.12.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-freebsd-arm64@npm:1.12.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-freebsd-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-freebsd-x64@npm:1.12.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-linux-arm64@npm:1.12.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-linux-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-linux-x64@npm:1.12.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-openbsd-arm64@npm:1.12.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-openbsd-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-openbsd-x64@npm:1.12.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-arm64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-windows-arm64@npm:1.12.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lefthook-windows-x64@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook-windows-x64@npm:1.12.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lefthook@npm:1.12.2":
+  version: 1.12.2
+  resolution: "lefthook@npm:1.12.2"
+  dependencies:
+    lefthook-darwin-arm64: 1.12.2
+    lefthook-darwin-x64: 1.12.2
+    lefthook-freebsd-arm64: 1.12.2
+    lefthook-freebsd-x64: 1.12.2
+    lefthook-linux-arm64: 1.12.2
+    lefthook-linux-x64: 1.12.2
+    lefthook-openbsd-arm64: 1.12.2
+    lefthook-openbsd-x64: 1.12.2
+    lefthook-windows-arm64: 1.12.2
+    lefthook-windows-x64: 1.12.2
+  dependenciesMeta:
+    lefthook-darwin-arm64:
+      optional: true
+    lefthook-darwin-x64:
+      optional: true
+    lefthook-freebsd-arm64:
+      optional: true
+    lefthook-freebsd-x64:
+      optional: true
+    lefthook-linux-arm64:
+      optional: true
+    lefthook-linux-x64:
+      optional: true
+    lefthook-openbsd-arm64:
+      optional: true
+    lefthook-openbsd-x64:
+      optional: true
+    lefthook-windows-arm64:
+      optional: true
+    lefthook-windows-x64:
+      optional: true
+  bin:
+    lefthook: bin/index.js
+  checksum: 5a6a5bc5b02aca102acd83f7233f53ea6bce5cb27054d5be5abe5804bfc52c3afe0aa667d2b3a35186979f1b93b1e2f2fe768a0c72deee413f5fc2c5a8620815
+  languageName: node
+  linkType: hard
+
 "leven@npm:^3.1.0":
   version: 3.1.0
   resolution: "leven@npm:3.1.0"
@@ -22237,12 +22338,12 @@ __metadata:
     "@changesets/changelog-github": ^0.5.1
     "@changesets/cli": ^2.28.1
     "@commitlint/config-conventional": 17.6.6
-    "@evilmartians/lefthook": 1.12.2
     commitlint: 17.6.6
     eslint: ^8.46.0
     eslint-plugin-flowtype: ^8.0.3
     eslint-plugin-prettier: ^5.5.3
     expo: ~52.0.36
+    lefthook: 1.12.2
     prettier: ^3.6.2
     typescript: ^5.1.3
   languageName: unknown


### PR DESCRIPTION
Let's move lint steps from pre-commit to pre-push, so that folks preferring `git merge` over `git rebase` are not disadvantaged when syncing their local feature branches with remote main branch

According to docs, the `lefthook` NPM package is the main one, so let's migrate from the legacy package

Additionally, the command building prod version of visualizer is moved to separate command, so that `typescript` step in `pre-push` doesn't last almost 30s