### PR TITLE
feat(#112): properly support version field in "getLibrariesAsync" function

### DIFF
--- a/.changeset/tame-buses-stop.md
+++ b/.changeset/tame-buses-stop.md
@@ -1,0 +1,5 @@
+---
+'react-native-legal': 'minor'
+---
+
+Support `version` field in `Library` type returned via `getLibrariesAsync` function

--- a/examples/bare-example/e2e/checkLicenses/ios-get-licenses.yaml
+++ b/examples/bare-example/e2e/checkLicenses/ios-get-licenses.yaml
@@ -15,16 +15,16 @@ tags:
     end: 50%, 0%
 - scrollUntilVisible:
     label: Scroll to React Native library
-    element: '@react-native/virtualized-lists (.*)'
+    element: '@react-native/virtualized-lists'
     direction: 'DOWN'
     timeout: 60000
     speed: 80
     visibilityPercentage: 75
 - takeScreenshot: 'e2e_results/getLicenses-react-native_list_element'
-- tapOn: '@react-native/virtualized-lists (.*)'
+- tapOn: '@react-native/virtualized-lists'
 - takeScreenshot: 'e2e_results/getLicenses-react-native_entry'
 - assertVisible: 'Exit detail view'
-- assertVisible: '@react-native/virtualized-lists (.*)'
+- assertVisible: '@react-native/virtualized-lists'
 - assertVisible: '.*MIT.*'
 - tapOn: 'Exit detail view'
 - takeScreenshot: 'e2e_results/react-native_back_to_list'

--- a/examples/common-ui/src/CustomListDetails.tsx
+++ b/examples/common-ui/src/CustomListDetails.tsx
@@ -12,6 +12,7 @@ export const CustomListDetails = ({ item, onModalClose }: Props) => {
       <Button onPress={onModalClose} title="Exit detail view" />
       <ScrollView style={styles.scroll}>
         <Text style={styles.header}>{item.name}</Text>
+        {item.version ? <Text style={styles.subheader}>Version: {item.version}</Text> : null}
         <Text style={styles.content}>
           {item.licenses.map((license) => license.licenseContent).reduce((a, c) => a + '\n' + c, '')}
         </Text>
@@ -35,6 +36,11 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: 'bold',
     margin: 8,
+  },
+  subheader: {
+    fontSize: 20,
+    fontWeight: 'semibold',
+    margin: 4,
   },
   scroll: {
     alignSelf: 'stretch',

--- a/packages/react-native-legal/android/src/main/java/com/reactnativelegal/ReactNativeLegalModuleImpl.kt
+++ b/packages/react-native-legal/android/src/main/java/com/reactnativelegal/ReactNativeLegalModuleImpl.kt
@@ -44,6 +44,7 @@ object ReactNativeLegalModuleImpl {
             bundleOf(
                 "id" to library.uniqueId,
                 "name" to library.name,
+                "version" to library.artifactVersion,
                 "description" to library.description,
                 "website" to library.website,
                 "developers" to library.developers.joinToString(),

--- a/packages/react-native-legal/ios/ReactNativeLegalModuleImpl.swift
+++ b/packages/react-native-legal/ios/ReactNativeLegalModuleImpl.swift
@@ -49,12 +49,33 @@ public class ReactNativeLegalModuleImpl: NSObject {
 
     return [
       "data": libraries.map({ library in
-        [
-          "id": "library-\(library.name ?? "")", "name": library.name ?? "",
+        let (name, version) = splitNameAndVersion(library.name)
+        return [
+          "id": "library-\(library.name ?? "")",
+          "name": name ?? "",
+          "version": version as Any,
           "licenses": [["licenseContent": library.content ?? ""]],
         ]
       })
     ]
+  }
+
+  private static func splitNameAndVersion(_ nameAndVersionStr: String?) -> (
+    name: String?, version: String?
+  ) {
+    guard let nameAndVersion = nameAndVersionStr else {
+      return (nil, nil)
+    }
+    var elements = nameAndVersion.split(separator: " ")
+    if elements.count <= 1 {
+      return (nameAndVersion, nil)
+    }
+    var version = elements.removeLast()
+    version.removeFirst()  // remove "("
+    version.removeLast()  // remove ")"
+    let name = elements.joined(separator: " ")
+
+    return (name, String(version))
   }
 
   private static func getChildPaneSpecifiers(dictArray: [[String: Any]]) -> [[String: Any]] {

--- a/packages/react-native-legal/src/NativeReactNativeLegal.ts
+++ b/packages/react-native-legal/src/NativeReactNativeLegal.ts
@@ -21,6 +21,7 @@ export interface Library {
   id: string;
   name: string;
   licenses: License[];
+  version?: string;
   /**
    * @platform Android
    */


### PR DESCRIPTION
Closes #112 

This PR implements support for retrieving version of each library via `getLibrariesAsync` function
- On Android it uses `artifactVersion` if it exists
- On iOS it parses the metadata from `Settings.bundle` (in `${name} (${version})` format) and returns version value if it exists