### PR TITLE
ci: pin SHA checksums of actions, disable cache in docs & package deploy workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,13 +1,26 @@
 name: Setup
 description: Setup Node.js and install dependencies
 
+inputs:
+  enable-cache:
+    description: When true, enable Yarn dependency caching in actions/setup-node
+    required: true
+    type: boolean
+
 runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      if: ${{ inputs.enable-cache }}
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        cache: 'yarn'
+        cache: yarn
+        node-version: 24
+
+    - name: Setup Node.js
+      if: ${{ !inputs.enable-cache }}
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
         node-version: 24
 
     - name: Install dependencies

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,14 +21,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: false
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Install dependencies
         working-directory: docs
@@ -40,7 +42,7 @@ jobs:
           yarn run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/doc_build
 
@@ -55,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/lint-android.yml
+++ b/.github/workflows/lint-android.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       
       - name: Set Java version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -15,12 +15,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: true
 
       - name: Run linter
         run: yarn lint:docs

--- a/.github/workflows/lint-objc.yml
+++ b/.github/workflows/lint-objc.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       
       - name: Lint ObjC with clang-format
-        uses: RafikFarhad/clang-format-github-action@v4
+        uses: RafikFarhad/clang-format-github-action@27cc2adf6e733d30c8ce3ca3944f3b2c7b13e1f5 # v6.0.1
         with:
           sources: "packages/react-native-legal/**/*.h,packages/react-native-legal/**/*.m,packages/react-native-legal/**/*.mm"
           style: file

--- a/.github/workflows/lint-swift.yml
+++ b/.github/workflows/lint-swift.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       
       - name: Install Swift
-        uses: swift-actions/setup-swift@v2
+        uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2.4.0
         with:
           swift-version: '6'
 

--- a/.github/workflows/lint-ts.yml
+++ b/.github/workflows/lint-ts.yml
@@ -23,12 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: true
 
       - name: Run linter
         run: yarn lint:js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,22 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
+      
+      - name: Setup
+        uses: ./.github/actions/setup
         with:
-          node-version: 24
-          cache: yarn
-
-      - name: Install Dependencies
-        run: yarn install --immutable
+          enable-cache: false
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1.7.0
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: yarn run version
           commit: "chore: version packages"

--- a/.github/workflows/test-e2e-android.yaml
+++ b/.github/workflows/test-e2e-android.yaml
@@ -44,12 +44,14 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: true
 
       - name: Install Maestro
         uses: ./.github/actions/installMaestro

--- a/.github/workflows/test-e2e-ios.yaml
+++ b/.github/workflows/test-e2e-ios.yaml
@@ -38,12 +38,14 @@ jobs:
         simulator: ['iPhone 16 Pro (18.5)']
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: true
 
       - name: Install Maestro
         uses: ./.github/actions/installMaestro

--- a/.github/workflows/test-integration-node.yml
+++ b/.github/workflows/test-integration-node.yml
@@ -25,12 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: true
 
       - name: Run integration tests
         run: yarn workspace license-kit-node-example test

--- a/.github/workflows/test-unit-licenses-api.yml
+++ b/.github/workflows/test-unit-licenses-api.yml
@@ -22,12 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          enable-cache: true
 
       - name: Run unit tests
         run: yarn workspace @callstack/licenses test


### PR DESCRIPTION
This PR:
- pins SHA checksums of all actions
- following the [TanStack postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem), disables caching in docs deploy & release workflows