### PR TITLE
fix(@callstack/licenses): sanitize unsafe characters in AboutLibraries license filenames

### DIFF
--- a/.changeset/sanitize-license-filename.md
+++ b/.changeset/sanitize-license-filename.md
@@ -1,0 +1,5 @@
+---
+'@callstack/licenses': patch
+---
+
+Sanitize unsafe characters in `prepareAboutLibrariesLicenseField` so packages with legacy or compound SPDX expressions (e.g. `MIT/X11`, `(MIT OR Apache-2.0)`) no longer break the AboutLibraries metadata generation on Android. Previously the unsanitized `/` caused `writeAboutLibrariesNPMOutput` to attempt creating files like `android/config/licenses/MIT/X11_<hash>.json`, failing with `ENOENT` because `MIT/` was treated as a subdirectory.

--- a/packages/licenses-api/src/node/utils/__tests__/packageUtils.test.ts
+++ b/packages/licenses-api/src/node/utils/__tests__/packageUtils.test.ts
@@ -1,4 +1,16 @@
-import { parseAuthorField, parseLicenseField } from '../packageUtils';
+import type { License } from '../../../types';
+import { sha512 } from '../miscUtils';
+import { parseAuthorField, parseLicenseField, prepareAboutLibrariesLicenseField } from '../packageUtils';
+
+const makeLicense = (overrides: Partial<License>): License =>
+  ({
+    name: 'pkg',
+    version: '1.0.0',
+    dependencyType: 'dependency',
+    requiredVersion: '1.0.0',
+    parentPackages: [],
+    ...overrides,
+  }) as License;
 
 describe('parseAuthorField', () => {
   it('should return author name when author is an object with name field', () => {
@@ -49,5 +61,41 @@ describe('parseLicenseField', () => {
     const json = { license: undefined as any };
 
     expect(parseLicenseField(json)).toBeUndefined();
+  });
+});
+
+describe('prepareAboutLibrariesLicenseField', () => {
+  it('returns empty string when license type is missing', () => {
+    expect(prepareAboutLibrariesLicenseField(makeLicense({}))).toBe('');
+  });
+
+  it('builds <type>_<hash> for plain license types', () => {
+    const result = prepareAboutLibrariesLicenseField(makeLicense({ type: 'MIT', content: 'license body' }));
+
+    expect(result).toBe(`MIT_${sha512('license body')}`);
+  });
+
+  it('sanitizes "/" so legacy SPDX like "MIT/X11" does not create a subdirectory on disk', () => {
+    const result = prepareAboutLibrariesLicenseField(
+      makeLicense({ name: 'nub', type: 'MIT/X11', content: 'license body' }),
+    );
+
+    expect(result).not.toContain('/');
+    expect(result.startsWith('MIT_X11_')).toBe(true);
+  });
+
+  it('sanitizes parentheses and spaces in compound SPDX expressions', () => {
+    const result = prepareAboutLibrariesLicenseField(
+      makeLicense({ type: '(MIT OR Apache-2.0)', content: 'license body' }),
+    );
+
+    expect(result).not.toMatch(/[()\s]/);
+    expect(result.startsWith('_MIT_OR_Apache-2.0__')).toBe(true);
+  });
+
+  it('hashes the sanitized type when content is absent so the prefix matches the hash input', () => {
+    const result = prepareAboutLibrariesLicenseField(makeLicense({ type: 'MIT/X11' }));
+
+    expect(result).toBe(`MIT_X11_${sha512('MIT_X11')}`);
   });
 });

--- a/packages/licenses-api/src/node/utils/packageUtils.ts
+++ b/packages/licenses-api/src/node/utils/packageUtils.ts
@@ -59,7 +59,14 @@ export function prepareAboutLibrariesLicenseField(license: License) {
     return '';
   }
 
-  return `${license.type}_${sha512(license.content ?? license.type)}`;
+  // The returned value is used as a filename under `android/config/licenses/`.
+  // Legacy/compound SPDX expressions like `MIT/X11` or `(MIT OR Apache-2.0)` would
+  // otherwise produce paths containing `/`, `(` or spaces, which causes the writer
+  // to either fail with ENOENT (when a `/` is interpreted as a subdirectory) or
+  // to produce names that are invalid on some filesystems.
+  const sanitizedType = license.type.replace(/[^A-Za-z0-9._-]/g, '_');
+
+  return `${sanitizedType}_${sha512(license.content ?? sanitizedType)}`;
 }
 
 export function parseAuthorField(json: { author: string | { name: string } }) {


### PR DESCRIPTION
## Summary

`prepareAboutLibrariesLicenseField` uses `license.type` verbatim as part of a filename written under `android/config/licenses/` by `writeAboutLibrariesNPMOutput`. When a dependency declares a legacy SPDX expression like `MIT/X11` (e.g. [`nub@0.0.0`](https://www.npmjs.com/package/nub/v/0.0.0) or [`optimist`](https://www.npmjs.com/package/optimist)), the unsanitized `/` causes the writer to attempt to create `android/config/licenses/MIT/X11_<hash>.json`. That fails with `ENOENT` because `MIT/` is interpreted as a subdirectory that doesn't exist.

This PR sanitizes any character outside `[A-Za-z0-9._-]` to `_` before constructing both the filename prefix and the sha512 input (when `content` is absent), so the prefix and hash stay consistent and the filename is always valid.

## Repro

Without this fix, against `@callstack/licenses@0.3.1`:

```js
// package.json depends on nub@0.0.0
const { scanDependencies, writeAboutLibrariesNPMOutput } = require('@callstack/licenses');

const licenses = scanDependencies('./package.json', () => ({
  includeTransitiveDependencies: true,
}));
writeAboutLibrariesNPMOutput(licenses, './android');
```

Throws:

```
ENOENT: no such file or directory, open
  '<cwd>/android/config/licenses/MIT/X11_<hash>.json'
```

After this PR, the same script writes `android/config/licenses/MIT_X11_<hash>.json` successfully, and `libraryJsonPayload.licenses[0]` matches `licenseJsonPayload.hash`.

## Behaviour change

| `license.type` | Before | After |
| --- | --- | --- |
| `MIT` | `MIT_<hash>` | `MIT_<hash>` (unchanged) |
| `Apache-2.0` | `Apache-2.0_<hash>` | `Apache-2.0_<hash>` (unchanged) |
| `MIT/X11` | `MIT/X11_<hash>` (ENOENT on write) | `MIT_X11_<hash>` |
| `(MIT OR Apache-2.0)` | `(MIT OR Apache-2.0)_<hash>` (unsafe) | `_MIT_OR_Apache-2.0__<hash>` |
| `LGPL-2.1-only WITH Classpath-exception-2.0` | unchanged (unsafe) | `LGPL-2.1-only_WITH_Classpath-exception-2.0_<hash>` |

The allowlist approach (vs. blocklisting just `/()`) is chosen because other compound SPDX expressions can also produce filenames that are invalid on some filesystems.

## Why this matters

Without this fix, any project depending (even transitively) on a package with such a license expression will fail Android license metadata generation entirely (the first throw aborts the loop), or produce an incomplete `android/config/licenses/` directory, leading to a missing or broken OSS notice screen.

## Test plan

- Added unit tests in `packages/licenses-api/src/node/utils/__tests__/packageUtils.test.ts`:
  - Missing license type
  - Plain `MIT`
  - Legacy `MIT/X11` (the reproduction case)
  - Compound `(MIT OR Apache-2.0)`
  - Hash consistency when `content` is absent (sanitized type is hashed, matching the prefix)
- `yarn workspace @callstack/licenses test` → 52 passing
- `yarn typescript`
- `yarn lint:js`

## Checklist

- [x] Added a changeset (`patch` bump for `@callstack/licenses`)
- [x] Added unit tests
- [x] Conventional commit message
