### PR TITLE
fix(#174): omitted parts of license content on iOS

### DIFF
--- a/.changeset/green-ideas-check.md
+++ b/.changeset/green-ideas-check.md
@@ -1,0 +1,5 @@
+---
+'react-native-legal': patch
+---
+
+Fix omitted parts of license content on iOS

--- a/packages/react-native-legal/ios/ReactNativeLegalModuleImpl.swift
+++ b/packages/react-native-legal/ios/ReactNativeLegalModuleImpl.swift
@@ -101,12 +101,12 @@ public class ReactNativeLegalModuleImpl: NSObject {
           .appendingPathExtension("plist")
 
         guard
-          let data = parsePlistToDictArray(fileUrl: fileUrl),
-          let item = data.first(where: { $0["FooterText"] != nil }),
-          let footerText = item["FooterText"] as? String
+          let data = parsePlistToDictArray(fileUrl: fileUrl)
         else {
           return ReactNativeLegalLicenseMetadata(name: title)
         }
+
+        let footerText = data.compactMap { $0["FooterText"] as? String }.joined(separator: "\n")
 
         return ReactNativeLegalLicenseMetadata(name: title, content: footerText)
       }


### PR DESCRIPTION
closes #174 