### PR TITLE
feat(#180): add Swift Package Manager support

### DIFF
--- a/.changeset/early-goats-hug.md
+++ b/.changeset/early-goats-hug.md
@@ -1,0 +1,5 @@
+---
+'react-native-legal': minor
+---
+
+Add (experimental) Swift Package Manager support (from RN 0.87)

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ packages/*/build/
 # Expo example
 examples/expo-example/android
 examples/expo-example/ios/
+
+# SPM
+.build/

--- a/packages/react-native-legal/Package.swift
+++ b/packages/react-native-legal/Package.swift
@@ -1,0 +1,56 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "ReactNativeLegal",
+    platforms: [.iOS(.v15), .tvOS(.v15)],
+    products: [
+        .library(name: "ReactNativeLegal", targets: ["ReactNativeLegalObjC"]),
+    ],
+    dependencies: [
+        .package(name: "ReactNative", path: "../../../../xcframeworks"),
+        .package(name: "React-GeneratedCode", path: "../../../ios"),
+    ],
+    targets: [
+        .target(
+            name: "ReactNativeLegalSwift",
+            path: ".",
+            sources: [
+                "ios/ReactNativeLegalDetailViewController.swift",
+                "ios/ReactNativeLegalLicenseMetadata.swift",
+                "ios/ReactNativeLegalModuleImpl.swift",
+                "ios/ReactNativeLegalTableViewController.swift",
+            ],
+            publicHeadersPath: "ios",
+            cSettings: [.headerSearchPath("ios")],
+            cxxSettings: [.headerSearchPath("ios"), .define("DEBUG", .when(configuration: .debug)), .define("NDEBUG", .when(configuration: .release))],
+            linkerSettings: [.linkedFramework("UIKit"), .linkedFramework("Foundation"), .linkedFramework("CoreGraphics")]
+        ),
+        .target(
+            name: "ReactNativeLegalObjC",
+            dependencies: [
+                "ReactNativeLegalSwift",
+                .product(name: "ReactHeaders", package: "ReactNative"),
+                .product(name: "ReactNativeHeaders", package: "ReactNative"),
+                .product(name: "ReactNativeDependenciesHeaders", package: "ReactNative"),
+                .product(name: "ReactAppHeaders", package: "React-GeneratedCode"),
+            ],
+            path: ".",
+            sources: [
+                "ios/ReactNativeLegalModule.h",
+                "ios/ReactNativeLegalModule.mm",
+            ],
+            publicHeadersPath: "ios",
+            cSettings: [.headerSearchPath("ios"), .define("REACT_NATIVE_LEGAL_USING_SPM")],
+            cxxSettings: [
+                .headerSearchPath("ios"),
+                .define("REACT_NATIVE_LEGAL_USING_SPM"),
+                .define("DEBUG", .when(configuration: .debug)),
+                .define("NDEBUG", .when(configuration: .release)),
+                .unsafeFlags(["-fmodules", "-fcxx-modules"])
+            ],
+            linkerSettings: [.linkedFramework("UIKit"), .linkedFramework("Foundation"), .linkedFramework("CoreGraphics")]
+        )
+    ],
+    cxxLanguageStandard: .cxx20
+)

--- a/packages/react-native-legal/bare-plugin/tsconfig.json
+++ b/packages/react-native-legal/bare-plugin/tsconfig.json
@@ -2,18 +2,19 @@
   "compilerOptions": {
     "declaration": true,
     "lib": ["es2020"],
-    "module": "commonjs",
+    "module": "node16",
     "target": "es2020",
 
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
 
     "outDir": "build",
     "rootDir": "src",
-    "typeRoots": ["../types-definitions", "../../../node_modules/@types"]
+    "typeRoots": ["../types-definitions", "../../../node_modules/@types"],
+    "types": ["node", "xcode"]
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]

--- a/packages/react-native-legal/ios/ReactNativeLegalDetailViewController.swift
+++ b/packages/react-native-legal/ios/ReactNativeLegalDetailViewController.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 class ReactNativeLegalDetailViewController: UIViewController {
   private var licenseContentTextView: UITextView = {
     let textView = UITextView()

--- a/packages/react-native-legal/ios/ReactNativeLegalModule.mm
+++ b/packages/react-native-legal/ios/ReactNativeLegalModule.mm
@@ -1,9 +1,17 @@
 #import "ReactNativeLegalModule.h"
 
+#import <React/RCTUtils.h>
+
+#ifdef REACT_NATIVE_LEGAL_USING_SPM
+@import ReactNativeLegalSwift;
+#else
+
 #if __has_include(<ReactNativeLegal/ReactNativeLegal-Swift.h>)
 #import <ReactNativeLegal/ReactNativeLegal-Swift.h>
 #else
 #import "ReactNativeLegal-Swift.h"
+#endif
+
 #endif
 
 #if RCT_NEW_ARCH_ENABLED
@@ -19,7 +27,10 @@ RCT_EXPORT_MODULE(ReactNativeLegalModule)
 
 RCT_EXPORT_METHOD(launchLicenseListScreen : (NSString *)licenseHeaderText)
 {
-  [ReactNativeLegalModuleImpl launchLicenseListScreenWithLicenseHeaderText:licenseHeaderText];
+  [ReactNativeLegalModuleImpl launchLicenseListScreenWithLicenseHeaderText:licenseHeaderText
+                                                getPresentedViewController:^{
+                                                  return RCTPresentedViewController();
+                                                }];
 }
 
 RCT_EXPORT_METHOD(getLibrariesAsync : (RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject)

--- a/packages/react-native-legal/ios/ReactNativeLegalModuleImpl.swift
+++ b/packages/react-native-legal/ios/ReactNativeLegalModuleImpl.swift
@@ -2,7 +2,10 @@ import UIKit
 
 @objc(ReactNativeLegalModuleImpl)
 public class ReactNativeLegalModuleImpl: NSObject {
-  @objc public static func launchLicenseListScreen(licenseHeaderText: String) {
+  @objc public static func launchLicenseListScreen(
+    licenseHeaderText: String,
+    getPresentedViewController: @Sendable @escaping () -> UIViewController?
+  ) {
     guard
       let settingsBundleUrl = Bundle.main.url(forResource: "Settings", withExtension: "bundle"),
       let settingsBundle = Bundle(url: settingsBundleUrl),
@@ -19,7 +22,7 @@ public class ReactNativeLegalModuleImpl: NSObject {
     )
 
     DispatchQueue.main.async {
-      guard let presentedViewController = RCTPresentedViewController() else {
+      guard let presentedViewController = getPresentedViewController() else {
         return
       }
 

--- a/packages/react-native-legal/ios/ReactNativeLegalTableViewController.swift
+++ b/packages/react-native-legal/ios/ReactNativeLegalTableViewController.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 class ReactNativeLegalTableViewController: UITableViewController {
   private let cellIdentifier = "ReactNativeLegalCell"
 

--- a/packages/react-native-legal/package.json
+++ b/packages/react-native-legal/package.json
@@ -37,8 +37,11 @@
     "plugin",
     "plugin-utils",
     "src",
+    "swift-tools/Package.resolved",
+    "swift-tools/Package.swift",
     "LICENSE",
     "app.plugin.js",
+    "Package.swift",
     "react-native.config.js",
     "ReactNativeLegal.podspec"
   ],

--- a/packages/react-native-legal/plugin-utils/src/ios.ts
+++ b/packages/react-native-legal/plugin-utils/src/ios.ts
@@ -39,11 +39,27 @@ export function registerLicensePlistBuildPhaseUtil(
   projectTargetId: string,
   pbxproj: XcodeProject, // Xcode Pbxproj
 ) {
+  const licensePlistFlags = '--add-version-numbers --output-path ./Settings.bundle';
+  const licensePlistShellScript = `set -e\\n\\nif [[ -n \${PODS_ROOT} ]]; then \${PODS_ROOT}/LicensePlist/license-plist ${licensePlistFlags}; else /usr/bin/env xcrun --sdk macosx swift run -c release --package-path ./build/generated/autolinking/libs/ReactNativeLegal/swift-tools license-plist ${licensePlistFlags}; fi\\n`;
   const nativeTargetSection = pbxproj.pbxNativeTargetSection();
   const nativeTarget = nativeTargetSection[projectTargetId];
 
-  if (pbxproj.buildPhase(GENERATE_LICENSE_PLIST_BUILD_PHASE_COMMENT, projectTargetId)) {
-    console.log(`LicensePlist buildPhase already added in "${nativeTarget.name}" - SKIP`);
+  const existingBuildPhase = pbxproj.buildPhaseObject(
+    'PBXShellScriptBuildPhase',
+    GENERATE_LICENSE_PLIST_BUILD_PHASE_COMMENT,
+    projectTargetId,
+  );
+
+  if (existingBuildPhase) {
+    const licensePlistShellScriptWithDoubleQuotes = '"' + licensePlistShellScript + '"';
+
+    if (existingBuildPhase.shellScript === licensePlistShellScriptWithDoubleQuotes) {
+      console.log(`LicensePlist buildPhase already added in "${nativeTarget.name}" - SKIP`);
+    } else {
+      existingBuildPhase.shellScript = licensePlistShellScriptWithDoubleQuotes;
+      console.log(`LicensePlist buildPhase in "${nativeTarget.name}" - MODIFIED`);
+    }
+
     return pbxproj;
   }
 
@@ -59,7 +75,7 @@ export function registerLicensePlistBuildPhaseUtil(
     projectTargetId,
     {
       shellPath: '/bin/sh',
-      shellScript: '${PODS_ROOT}/LicensePlist/license-plist --add-version-numbers --output-path ./Settings.bundle',
+      shellScript: licensePlistShellScript,
     },
   );
   /**

--- a/packages/react-native-legal/plugin-utils/tsconfig.json
+++ b/packages/react-native-legal/plugin-utils/tsconfig.json
@@ -1,19 +1,20 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "lib": ["es2020"],
-    "module": "commonjs",
+    "lib": ["es2020", "DOM"],
+    "module": "node16",
     "target": "es2020",
 
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
 
     "outDir": "build",
     "rootDir": "src",
-    "typeRoots": ["../types-definitions", "../../../node_modules/@types"]
+    "typeRoots": ["../types-definitions", "../../../node_modules/@types"],
+    "types": ["node", "xcode"]
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*"]

--- a/packages/react-native-legal/swift-tools/Package.resolved
+++ b/packages/react-native-legal/swift-tools/Package.resolved
@@ -1,0 +1,96 @@
+{
+  "originHash" : "cee7bf8ff6206ef1f83a8d7f34e0a0b8ad3e2b2f0097d8f6864806fc464ba4ed",
+  "pins" : [
+    {
+      "identity" : "apikit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ishkawa/APIKit.git",
+      "state" : {
+        "revision" : "b839e53b870104798035b279d2a6168b0a2227b1",
+        "version" : "5.4.0"
+      }
+    },
+    {
+      "identity" : "heliumlogger",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/HeliumLogger.git",
+      "state" : {
+        "revision" : "fc2a71597ae974da5282d751bcc11965964bccce",
+        "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "licenseplist",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mono0926/LicensePlist",
+      "state" : {
+        "revision" : "af8dd93bcf798fc70e648f489a14423ea9105334",
+        "version" : "3.28.0"
+      }
+    },
+    {
+      "identity" : "loggerapi",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/LoggerAPI.git",
+      "state" : {
+        "revision" : "c26d5ef0009fbc0945326933e0f790bd33fe9062",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-html-entities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kitura/swift-html-entities.git",
+      "state" : {
+        "revision" : "d8ca73197f59ce260c71bd6d7f6eb8bbdccf508b",
+        "version" : "4.0.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    },
+    {
+      "identity" : "tomlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/LebJe/TOMLKit.git",
+      "state" : {
+        "revision" : "ec6198d37d495efc6acd4dffbd262cdca7ff9b3f",
+        "version" : "0.6.0"
+      }
+    },
+    {
+      "identity" : "xcodeedit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tomlokhorst/XcodeEdit.git",
+      "state" : {
+        "revision" : "0e550cdee72844b35431afc3a1e176042be6d0f0",
+        "version" : "2.13.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/packages/react-native-legal/swift-tools/Package.swift
+++ b/packages/react-native-legal/swift-tools/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+  name: "Tools",
+  platforms: [
+    .macOS(.v11)
+  ],
+  dependencies: [
+    .package(url: "https://github.com/mono0926/LicensePlist", from: "3.28.0")
+  ],
+  targets: [
+    .target(name: "Tools", path: "")
+  ]
+)

--- a/packages/react-native-legal/tsconfig.json
+++ b/packages/react-native-legal/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "esModuleInterop": true,
@@ -8,7 +7,7 @@
     "jsx": "react",
     "lib": ["esnext"],
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitUseStrict": false,

--- a/packages/react-native-legal/types-definitions/xcode.d.ts
+++ b/packages/react-native-legal/types-definitions/xcode.d.ts
@@ -140,6 +140,10 @@ declare module 'xcode' {
         buildActionMask: number;
         files: unknown[];
         runOnlyForDeploymentPostprocessing: number;
+        inputPaths?: string[];
+        outputPaths?: string[];
+        shellPath: string;
+        shellScript: string;
       };
     };
     addFile(path: string, group?: string, opt?: FileOptions): pbxFile | null;
@@ -147,6 +151,20 @@ declare module 'xcode' {
     addToPbxBuildFileSection(file: pbxFile): void;
     addToPbxResourcesBuildPhase(file: pbxFile): void;
     buildPhase(group: string, target: string): string | undefined;
+    buildPhaseObject(
+      name: string,
+      group: string,
+      target: string,
+    ): {
+      isa: string;
+      buildActionMask: number;
+      files: unknown[];
+      runOnlyForDeploymentPostprocessing: number;
+      inputPaths?: string[];
+      outputPaths?: string[];
+      shellPath: string;
+      shellScript: string;
+    } | null;
     findPBXGroupKey(criteria: { name?: string; path?: string }): string | undefined;
     generateUuid(): string;
     getFirstProject(): { uuid: string; firstProject: PBXProject };


### PR DESCRIPTION
Closes #180 

Swift Package Manager in RN apps is supported as an opt-in since v0.87

3rd party libraries with ObjC/ObjC++ only code are supported via `npx react-native spm scaffold` command which generates the `Package.swift` based on the existing `.podspec` file, which can later be upstreamed as a contribution to such library. This does not work, when 3p library mixes ObjC/ObjC++ and Swift - in that case the only solution so far is for the maintainers to configure support for `Package.swift` (using multiple targets, one for Swift and one for ObjC code)

This PR configures `Package.swift` and adjusts a bit the existing codebase to keep Swift and ObjC targets separate and to have ObjC target consume the Swift target. Additionally the plugin utils that registers LicensePlist build phase is adjusted to consume it via Swift Package instead of Pods (it is launched via `swift run` command that points to the path with separate `Package.swift`)

Test Plan:
- create RN 0.87 app
- do the `npm pack` in the `packages/react-native-legal`
- install library from produced tarball in the created RN 0.87 app
- run `npx react-native spm scaffold`
- run `npx react-native legal-generate`
- build and run iOS app (debug and release)